### PR TITLE
Change to the correct build script in the CI action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,4 +28,4 @@ jobs:
         run: bun typecheck
 
       - name: Build check
-        run: bun build
+        run: bun run build


### PR DESCRIPTION
## Description

In the initial setup of the CI action, the build step was set to run `bun build`, but the correct one is `bun run build`.